### PR TITLE
Add IP dropdown and port validation

### DIFF
--- a/VolumeControl/MainWindow.xaml
+++ b/VolumeControl/MainWindow.xaml
@@ -14,20 +14,42 @@
         <DropShadowEffect/>
     </Window.Effect>
     <Grid>
-        <TextBox x:Name="server_port" Height="23" Margin="148,47,249,0" TextWrapping="Wrap" Text="3000" VerticalAlignment="Top"/>
-        <Label Content="Your IP Address" HorizontalAlignment="Right" Margin="0,12,413,0" VerticalAlignment="Top"/>
-        <Label x:Name="server_ip" Content="192.168.1.100" HorizontalAlignment="Right" Margin="0,43,369,0" VerticalAlignment="Top" Width="137"/>
-        <Label Content="Port" HorizontalAlignment="Left" Margin="148,12,0,0" VerticalAlignment="Top"/>
-        <Button x:Name="start_button" Content="Start" Margin="193,92,0,0" VerticalAlignment="Top" HorizontalAlignment="Left" Width="75" Click="start_button_Click"/>
-        <Label x:Name="server_status" Content="Offline" Margin="0,21,20,0" HorizontalAlignment="Right" Width="69" Height="26" VerticalAlignment="Top" FontWeight="Bold"/>
-        <Button x:Name="stop_button" Content="Stop" HorizontalAlignment="Left" Margin="289,92,0,0" VerticalAlignment="Top" Width="75" Click="stop_button_Click"/>
-        <Button x:Name="exit_button" Content="Exit" HorizontalAlignment="Left" Margin="422,92,0,0" VerticalAlignment="Top" Width="75" Click="exit_button_Click"/>
-        <Label x:Name="version_view_protocol" Content="V" Margin="0,0,0,18" HorizontalAlignment="Left" Width="167" Height="26" VerticalAlignment="Bottom"/>
-        <Label x:Name="version_view_app" Content="V" Margin="0,0,0,44" HorizontalAlignment="Left" Width="167" Height="26" VerticalAlignment="Bottom"/>
-        <TextBlock VerticalAlignment="Bottom" HorizontalAlignment="Left">
-            <Hyperlink RequestNavigate="DownloadLatest_RequestNavigate" NavigateUri="https://github.com/PcVolumeControl/PcVolumeControlWindows/releases/latest">Download latest Version</Hyperlink>
-        </TextBlock>
-        <Button x:Name="start_boot_button" Content="Start On Boot" Margin="415,134,10.4,0" VerticalAlignment="Top" Click="start_boot_Click"/>
-        <Button x:Name="stop_boot_button" Content="Remove On Boot" Margin="284,134,116.4,0" VerticalAlignment="Top" Click="stop_boot_Click"/>
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="Auto" />
+			<ColumnDefinition Width="1*" />
+			<ColumnDefinition Width="2*" />
+			<ColumnDefinition Width="1*" />
+		</Grid.ColumnDefinitions>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="1*" />
+			<RowDefinition Height="1*" />
+			<RowDefinition Height="1*" />
+			<RowDefinition Height="1*" />
+			<RowDefinition Height="1*" />
+		</Grid.RowDefinitions>
+		<Label Content="Server IP Address"/>
+		<Label Content="Port" Grid.Column="1"/>
+		<Label x:Name="server_status" Content="Offline" FontWeight="Bold" Grid.Column="3"/>
+
+		<StackPanel Grid.Row="1" Height="23" Margin="0,0,5,0">
+			<ComboBox x:Name="ipComboBox" IsEditable="True" ItemsSource="{Binding Addresses}">
+			</ComboBox>
+		</StackPanel>
+
+		<TextBox x:Name="server_port" TextWrapping="NoWrap" MaxLength="5" Text="3000" Height="23" Grid.Column="1" Grid.Row="1"/>
+
+		<Label x:Name="version_view_app" Content="V" Grid.Row="2"/>
+		<Button x:Name="start_button" Content="Start" Click="start_button_Click" Width="75" Grid.Row="1" Grid.Column="2" Margin="5"/>
+		<Button x:Name="stop_button" Content="Stop" Click="stop_button_Click" Width="75" Grid.Row="2" Grid.Column="2" Margin="5"/>
+		<Button x:Name="exit_button" Content="Exit" Click="exit_button_Click" Width="75" Grid.Row="2" Grid.Column="3" Margin="5"/>
+
+		<Label x:Name="version_view_protocol" Content="V" Grid.Row="3"/>
+
+		<Button x:Name="stop_boot_button" Content="Remove On Boot" Click="stop_boot_Click" Grid.Row="4" Grid.Column="2" Margin="5" Width="105"/>
+		<Button x:Name="start_boot_button" Content="Start On Boot" Click="start_boot_Click" Grid.Row="4" Grid.Column="3" Margin="5"/>
+
+		<TextBlock Grid.Row="4" Margin="1">
+			<Hyperlink RequestNavigate="DownloadLatest_RequestNavigate" NavigateUri="https://github.com/PcVolumeControl/PcVolumeControlWindows/releases/latest">Download Latest Version</Hyperlink>
+		</TextBlock>
     </Grid>
 </Window>

--- a/VolumeControl/MainWindow.xaml.cs
+++ b/VolumeControl/MainWindow.xaml.cs
@@ -17,6 +17,8 @@ namespace VolumeControl
 {
     public partial class MainWindow : Window
     {
+        string[] ips = App.GetLocalIPAddresses();
+
         public MainWindow()
         {
             InitializeComponent();
@@ -24,9 +26,9 @@ namespace VolumeControl
             version_view_protocol.Content = "protocol v" + App.PROTOCOL_VERSION;
             version_view_app.Content = "application " + App.APPLICATION_VERSION;
 
-            string ipAddress = App.GetLocalIPAddress();
-            server_ip.Content = ipAddress;
-            Console.WriteLine("ipAddress: " + ipAddress);
+            string[] ips = App.GetLocalIPAddresses();
+            ipComboBox.ItemsSource = ips;
+            ipComboBox.SelectedItem = ips[0]; // Initially listen on 0.0.0.0
 
             updateConnectionStatus();
 
@@ -51,6 +53,7 @@ namespace VolumeControl
                     start_button.IsEnabled = true;
                     stop_button.IsEnabled = false;
                     server_port.IsEnabled = true;
+                    ipComboBox.IsEnabled = true;
                 }
                 else
                 {
@@ -58,13 +61,37 @@ namespace VolumeControl
                     start_button.IsEnabled = false;
                     stop_button.IsEnabled = true;
                     server_port.IsEnabled = false;
+                    ipComboBox.IsEnabled = false;
                 }
             }));
         }
 
+        // The combobox is populated with this array.
+        public string[] Addresses
+        {
+            get { return ips; }
+        }
+
         private void start_button_Click(object sender, RoutedEventArgs e)
         {
-            App.instance.startServer();
+            bool valid = false;
+            bool isNumber = int.TryParse(server_port.Text, out int portNumber);
+            if (isNumber)
+            {
+                if (portNumber >= 1 && portNumber <= 65535)
+                {
+                    valid = true;
+                }
+            } 
+            if (valid)
+            {
+                string ipaddr = ipComboBox.SelectedItem.ToString();
+                App.instance.startServer(ipaddr, portNumber);
+            } 
+            else
+            {
+                MessageBox.Show("Listening TCP port must be between 1-65535", "PcVolumeControl", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
         }
 
         private void stop_button_Click(object sender, RoutedEventArgs e)

--- a/VolumeControl/Server.cs
+++ b/VolumeControl/Server.cs
@@ -18,12 +18,14 @@ namespace VolumeControl
         private bool m_running = false;
         private ASCIIEncoding m_encoder = new ASCIIEncoding();
 
-        public Server(ClientListener clientListener)
+        public Server(ClientListener clientListener, string address, int port)
         {
-            m_tcpListener = new TcpListener(IPAddress.Any, 3000);
+            var parsedAddress = IPAddress.Parse(address);
+            m_tcpListener = new TcpListener(parsedAddress, port);
             listenThread = new Thread(new ThreadStart(ListenForClients));
             listenThread.Start();
             m_clientListener = clientListener;
+            Console.WriteLine("Server listening on address: {0}:{1}", parsedAddress, port);
         }
 
         public bool isRunning()


### PR DESCRIPTION
The default behavior was the attach to 0.0.0.0 and not allow the port to be edited when initializing. This change allows the server to start up binding to all interfaces (previous behavior) on 3000, but when stopped it allows the user to select a specific IP to bind to.

Port validation was added to ensure they're not entering garbage input.